### PR TITLE
Update README.md to specify proper option for library usage case

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ inferred style to transform all .js files under the current directory.
 
 ```js
 codepaint.infer('sample.js', function(inferredStyle) {
-    codepainter.xform('**/**.js', {json: inferredStyle});
+    codepainter.xform('**/**.js', {style: inferredStyle});
 });
 ```
 


### PR DESCRIPTION
The documentation seems inaccurate here-- `inferredStyle` is JSON, not a path to a JSON file on disk, so the proper option should be `style`.
