### PR TITLE
Fix broken indent_size setting

### DIFF
--- a/lib/rules/indent_style_and_size.js
+++ b/lib/rules/indent_style_and_size.js
@@ -182,7 +182,7 @@ module.exports = util.inherits(IndentStyleAndSizeRule, Rule, {
 		}
 
 		this.prevToken = null;
-		this.indentOne = (settings.indent_style === 'tab') ? '	' : ' '.repeat(settings.indent_size);
+		this.indentOne = ((settings.indent_style === 'tab') ? '	' : ' ').repeat(settings.indent_size);
 
 		input.on('data', this.onTransformData.bind(this));
 		input.on('end', this.onTransformEnd.bind(this));


### PR DESCRIPTION
I think the indent size is intended to be `value.width`, not a string. Prior to this change, no transformation seems to occur when the inferred indentation character is tab.
