### PR TITLE
Do not output indent_size = 'tab'.

### DIFF
--- a/lib/rules/indent_style_and_size.js
+++ b/lib/rules/indent_style_and_size.js
@@ -154,7 +154,7 @@ module.exports = util.inherits(IndentStyleAndSizeRule, Rule, {
 		var settings = {};
 		if (value && value.character === '\t') {
 			settings.indent_style = 'tab';
-			settings.indent_size = 'tab';
+			settings.indent_size = null;
 		} else {
 			settings.indent_style = 'space';
 			settings.indent_size = value && value.width || 4;


### PR DESCRIPTION
`'tab'` is an invalid value for `indent_size` and breaks the .editorconfig parsing.

This fixes #35 by outputting `null` for `indent_size` when `indent_style` is `'tab'`.
