### PR TITLE
Upgrade editorconfig dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "cli-color": "^0.3.2",
-    "editorconfig": "^0.11.4",
+    "editorconfig": "^0.13.2",
     "esprima": "^1.2.2",
     "gitlike-cli": "^0.1.0",
     "glob": "^4.0.6",


### PR DESCRIPTION
The older version of editorconfig wasn't installing on OS X.

See https://github.com/editorconfig/editorconfig-core-js/issues/29
